### PR TITLE
Allow user to control the timezone by GUC.

### DIFF
--- a/src/timestamp9.c
+++ b/src/timestamp9.c
@@ -354,7 +354,7 @@ timestamp9_out(PG_FUNCTION_ARGS)
 	timestamp9 arg1 = PG_GETARG_TIMESTAMP9(0);
 	char *result = (char *) palloc(41);
 	time_t secs = (time_t)(arg1 / kT_ns_in_s);
-	struct tm tm_;
+	struct pg_tm *tm_;
 	size_t offset;
 	long long int mod = (arg1 % kT_ns_in_s);
 	if (mod < 0)
@@ -362,10 +362,11 @@ timestamp9_out(PG_FUNCTION_ARGS)
 		mod += kT_ns_in_s;
 		secs -= 1;
 	}
-	localtime_r(&secs, &tm_);
-	offset = strftime(result, 41, "%Y-%m-%d %H:%M:%S", &tm_);
+
+	tm_ = pg_localtime(&secs, session_timezone);
+	offset = pg_strftime(result, 41, "%Y-%m-%d %H:%M:%S", tm_);
 	offset += sprintf(result + offset, ".%09lld", mod);
-	offset += strftime(result + offset, 41, " %z", &tm_);
+	offset += pg_strftime(result + offset, 41, " %z", tm_);
 
 	PG_RETURN_CSTRING(result);
 }

--- a/src/timestamp9.c
+++ b/src/timestamp9.c
@@ -364,6 +364,11 @@ timestamp9_out(PG_FUNCTION_ARGS)
 	}
 
 	tm_ = pg_localtime(&secs, session_timezone);
+	if (!tm_)
+		ereport(ERROR,
+			(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+			 errmsg("timestamp9 out of range")));
+
 	offset = pg_strftime(result, 41, "%Y-%m-%d %H:%M:%S", tm_);
 	offset += sprintf(result + offset, ".%09lld", mod);
 	offset += pg_strftime(result + offset, 41, " %z", tm_);

--- a/tests/expected/basics.out
+++ b/tests/expected/basics.out
@@ -1,7 +1,11 @@
+-- Set timezone to UTC-2 so that timestamp9 can have consistent timezone configuration
+-- on machines in different timezones.
+set timezone to 'UTC-2';
+-- Test that we are able to convert nanoseconds to timestamp9.
 select 0::bigint::timestamp9;
              timestamp9              
 -------------------------------------
- 1970-01-01 01:00:00.000000000 +0100
+ 1970-01-01 02:00:00.000000000 +0200
 (1 row)
 
 select 9223372036854775807::timestamp9;
@@ -10,6 +14,7 @@ select 9223372036854775807::timestamp9;
  2262-04-12 01:47:16.854775807 +0200
 (1 row)
 
+-- Test that we are able to convert various formats of timestamps to timestamp9 type.
 select '2019-09-19 08:30:05.123456789 +0200'::timestamp9;
              timestamp9              
 -------------------------------------
@@ -37,18 +42,176 @@ select '2019-09-19 08:30:05.123456789 -02:00'::timestamp9;
 select '2019-09-19 08:30:05'::timestamp9;
              timestamp9              
 -------------------------------------
- 2019-09-19 17:30:05.000000000 +0200
+ 2019-09-19 08:30:05.000000000 +0200
 (1 row)
 
+-- Test that we are able to control the timezone of timestamp9 via the 'timezone' GUC.
+set timezone to 'UTC-8';
+select '2019-09-19 08:30:05 +0800'::timestamp9;
+             timestamp9              
+-------------------------------------
+ 2019-09-19 08:30:05.000000000 +0800
+(1 row)
+
+set timezone to 'Europe/London';
+select '2019-09-19 08:30:05 +0100'::timestamp9;
+             timestamp9              
+-------------------------------------
+ 2019-09-19 08:30:05.000000000 +0100
+(1 row)
+
+-- NOTE: If we don't specify the timezone when parsing the time, it follows the timezone
+-- of the current session by default.
+select '2019-09-19 08:30:05'::timestamp9;
+             timestamp9              
+-------------------------------------
+ 2019-09-19 08:30:05.000000000 +0100
+(1 row)
+
+set timezone to 'UTC-2';
+-- Test that we are able to compare timestamp9 values.
 select '2019-09-19'::timestamp9 < '2019-09-20'::timestamp9, greatest('2020-06-06'::timestamp9, '2019-01-01'::timestamp9);
  ?column? |              greatest               
 ----------+-------------------------------------
- t        | 2020-06-06 09:00:00.000000000 +0200
+ t        | 2020-06-06 00:00:00.000000000 +0200
 (1 row)
 
-select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1d';
+select '2019-09-19'::timestamp9 > '2019-09-20'::timestamp9, least('2020-06-06'::timestamp9, '2019-01-01'::timestamp9);
+ ?column? |                least                
+----------+-------------------------------------
+ f        | 2019-01-01 00:00:00.000000000 +0200
+(1 row)
+
+select '2019-09-19'::timestamp9 >= '2019-09-20'::timestamp9;
+ ?column? 
+----------
+ f
+(1 row)
+
+select '2019-09-20'::timestamp9 >= '2019-09-20'::timestamp9;
+ ?column? 
+----------
+ t
+(1 row)
+
+select '2019-09-19'::timestamp9 <= '2019-09-20'::timestamp9;
+ ?column? 
+----------
+ t
+(1 row)
+
+select '2019-09-20'::timestamp9 <= '2019-09-20'::timestamp9;
+ ?column? 
+----------
+ t
+(1 row)
+
+select '2019-09-19'::timestamp9 = '2019-09-20'::timestamp9;
+ ?column? 
+----------
+ f
+(1 row)
+
+select '2019-09-20'::timestamp9 = '2019-09-20'::timestamp9;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Test that we can do arith calculations with timestamp9.
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 year';
+              ?column?               
+-------------------------------------
+ 2020-09-19 23:00:00.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 years';
+              ?column?               
+-------------------------------------
+ 2017-09-19 23:00:00.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 mon';
+              ?column?               
+-------------------------------------
+ 2019-10-19 23:00:00.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 mons';
+              ?column?               
+-------------------------------------
+ 2019-07-19 23:00:00.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 day';
               ?column?               
 -------------------------------------
  2019-09-20 23:00:00.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 days';
+              ?column?               
+-------------------------------------
+ 2019-09-17 23:00:00.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 hour';
+              ?column?               
+-------------------------------------
+ 2019-09-20 00:00:00.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 hours';
+              ?column?               
+-------------------------------------
+ 2019-09-19 21:00:00.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 min';
+              ?column?               
+-------------------------------------
+ 2019-09-19 23:01:00.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 mins';
+              ?column?               
+-------------------------------------
+ 2019-09-19 22:58:00.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 sec';
+              ?column?               
+-------------------------------------
+ 2019-09-19 23:00:01.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 secs';
+              ?column?               
+-------------------------------------
+ 2019-09-19 22:59:58.123456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 millisecond';
+              ?column?               
+-------------------------------------
+ 2019-09-19 23:00:00.124456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 milliseconds';
+              ?column?               
+-------------------------------------
+ 2019-09-19 23:00:00.121456789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 microsecond';
+              ?column?               
+-------------------------------------
+ 2019-09-19 23:00:00.123457789 +0200
+(1 row)
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 microseconds';
+              ?column?               
+-------------------------------------
+ 2019-09-19 23:00:00.123454789 +0200
 (1 row)
 

--- a/tests/sql/basics.sql
+++ b/tests/sql/basics.sql
@@ -1,9 +1,60 @@
+-- Set timezone to UTC-2 so that timestamp9 can have consistent timezone configuration
+-- on machines in different timezones.
+set timezone to 'UTC-2';
+
+-- Test that we are able to convert nanoseconds to timestamp9.
 select 0::bigint::timestamp9;
 select 9223372036854775807::timestamp9;
+
+-- Test that we are able to convert various formats of timestamps to timestamp9 type.
 select '2019-09-19 08:30:05.123456789 +0200'::timestamp9;
 select '2019-09-19 08:30:05.123456789-0200'::timestamp9;
 select '2019-09-19 08:30:05.123456789+02:00'::timestamp9;
 select '2019-09-19 08:30:05.123456789 -02:00'::timestamp9;
 select '2019-09-19 08:30:05'::timestamp9;
+
+-- Test that we are able to control the timezone of timestamp9 via the 'timezone' GUC.
+set timezone to 'UTC-8';
+select '2019-09-19 08:30:05 +0800'::timestamp9;
+set timezone to 'Europe/London';
+select '2019-09-19 08:30:05 +0100'::timestamp9;
+-- NOTE: If we don't specify the timezone when parsing the time, it follows the timezone
+-- of the current session by default.
+select '2019-09-19 08:30:05'::timestamp9;
+set timezone to 'UTC-2';
+
+
+-- Test that we are able to compare timestamp9 values.
 select '2019-09-19'::timestamp9 < '2019-09-20'::timestamp9, greatest('2020-06-06'::timestamp9, '2019-01-01'::timestamp9);
-select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1d';
+select '2019-09-19'::timestamp9 > '2019-09-20'::timestamp9, least('2020-06-06'::timestamp9, '2019-01-01'::timestamp9);
+select '2019-09-19'::timestamp9 >= '2019-09-20'::timestamp9;
+select '2019-09-20'::timestamp9 >= '2019-09-20'::timestamp9;
+select '2019-09-19'::timestamp9 <= '2019-09-20'::timestamp9;
+select '2019-09-20'::timestamp9 <= '2019-09-20'::timestamp9;
+select '2019-09-19'::timestamp9 = '2019-09-20'::timestamp9;
+select '2019-09-20'::timestamp9 = '2019-09-20'::timestamp9;
+
+-- Test that we can do arith calculations with timestamp9.
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 year';
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 years';
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 mon';
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 mons';
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 day';
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 days';
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 hour';
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 hours';
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 min';
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 mins';
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 sec';
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 secs';
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 millisecond';
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 milliseconds';
+
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 microsecond';
+select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 microseconds';


### PR DESCRIPTION
This patch enables user to control the timezone of timestamp by the
timezone GUC. e.g.,

```
postgres=# select now()::timestamp9;
                 now
-------------------------------------
 2022-08-24 18:08:01.729360000 +0800
(1 row)

postgres=# set timezone to 'UTC+2';
SET
postgres=# select now()::timestamp9;
                 now
-------------------------------------
 2022-08-24 08:08:12.995542000 -0200
(1 row)
```

Sorry, I haven't been able to setup the regression test but I've tested it manually. I raise this
pull-request for discussion.