### PR TITLE
Add support for getting current timestamp in nano second precision.

### DIFF
--- a/src/timestamp9.c
+++ b/src/timestamp9.c
@@ -6,6 +6,7 @@
 #include <time.h>
 
 #include "access/hash.h"
+#include "access/xact.h"
 #include "catalog/pg_type.h"
 #include "libpq/pqformat.h"
 #include "utils/array.h"
@@ -46,6 +47,8 @@ PG_FUNCTION_INFO_V1(timestamp9_smaller);
 PG_FUNCTION_INFO_V1(timestamp9_interval_pl);
 PG_FUNCTION_INFO_V1(interval_timestamp9_pl);
 PG_FUNCTION_INFO_V1(timestamp9_interval_mi);
+
+PG_FUNCTION_INFO_V1(timestamp9_nsnow);
 
 #define kT_ns_in_s  (int64_t)1000000000
 #define kT_ns_in_us (int64_t)1000
@@ -646,4 +649,27 @@ Datum timestamp9_interval_mi(PG_FUNCTION_ARGS)
 																	IntervalPGetDatum(&tspan))));
 	new_ts += ts % 1000;
 	PG_RETURN_TIMESTAMP9(new_ts);
+}
+
+Datum
+timestamp9_nsnow(PG_FUNCTION_ARGS)
+{
+	timestamp9 result;
+	struct timespec tv;
+	static TimestampTz current_xact_timestamp;
+	static timestamp9 current_xact_ts9_timestamp;
+
+	if (current_xact_timestamp == GetCurrentTransactionStartTimestamp())
+		PG_RETURN_TIMESTAMP9(current_xact_ts9_timestamp);
+
+	if (clock_gettime(CLOCK_REALTIME, &tv))
+		ereport(ERROR, (errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				errmsg("cannot get current timestamp")));
+
+	result = tv.tv_sec * kT_ns_in_s;
+	result += tv.tv_nsec;
+
+	current_xact_timestamp = GetCurrentTransactionStartTimestamp();
+	current_xact_ts9_timestamp = result;
+	PG_RETURN_TIMESTAMP9(result);
 }

--- a/src/timestamp9.sql
+++ b/src/timestamp9.sql
@@ -224,3 +224,7 @@ CREATE OPERATOR + (
 	PROCEDURE = interval_timestamp9_pl,
 	COMMUTATOR = +
 	);
+
+CREATE FUNCTION timestamp9_nsnow() RETURNS timestamp9 AS
+'$libdir/timestamp9'
+	LANGUAGE c STABLE STRICT PARALLEL SAFE;

--- a/tests/expected/basics.out
+++ b/tests/expected/basics.out
@@ -242,3 +242,19 @@ select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 microseco
 CREATE TABLE tbl(ts timestamp9);
 CREATE INDEX ON tbl USING hash (ts);
 CREATE TABLE tbl1(ts timestamp9) PARTITION BY HASH (ts);
+-- Test that timestamp9_nsnow() returns same value in the same transaction.
+CREATE TABLE ts9_now(col1 timestamp9, col2 timestamp9);
+INSERT INTO ts9_now VALUES (timestamp9_nsnow(), timestamp9_nsnow()), (timestamp9_nsnow(), timestamp9_nsnow());
+BEGIN;
+INSERT INTO ts9_now VALUES (timestamp9_nsnow(), timestamp9_nsnow());
+INSERT INTO ts9_now VALUES (timestamp9_nsnow(), timestamp9_nsnow());
+END;
+SELECT col1=col2 FROM ts9_now;
+ ?column? 
+----------
+ t
+ t
+ t
+ t
+(4 rows)
+

--- a/tests/sql/basics.sql
+++ b/tests/sql/basics.sql
@@ -70,3 +70,12 @@ CREATE TABLE tbl(ts timestamp9);
 CREATE INDEX ON tbl USING hash (ts);
 
 CREATE TABLE tbl1(ts timestamp9) PARTITION BY HASH (ts);
+
+-- Test that timestamp9_nsnow() returns same value in the same transaction.
+CREATE TABLE ts9_now(col1 timestamp9, col2 timestamp9);
+INSERT INTO ts9_now VALUES (timestamp9_nsnow(), timestamp9_nsnow()), (timestamp9_nsnow(), timestamp9_nsnow());
+BEGIN;
+INSERT INTO ts9_now VALUES (timestamp9_nsnow(), timestamp9_nsnow());
+INSERT INTO ts9_now VALUES (timestamp9_nsnow(), timestamp9_nsnow());
+END;
+SELECT col1=col2 FROM ts9_now;


### PR DESCRIPTION
This patch adds support for getting current timestamp in nano second precision by using clock_gettime() [1]. I didn't have a Windows machine so I didn't implement it for Windows. Feedbacks are welcome.

[1] https://man7.org/linux/man-pages/man2/clock_gettime.2.html