### PR TITLE
Change operator class hash_timestamp9_ops to default

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(MOD_FILES
 	timestamp9--0.3.0--1.0.0.sql
 	timestamp9--1.0.0--1.0.1.sql
 	timestamp9--1.0.1--1.1.0.sql
+	timestamp9--1.1.0--1.2.0.sql
 		)
 
 add_custom_target(sqlupdatescripts ALL DEPENDS ${MOD_FILES})

--- a/src/timestamp9--1.1.0--1.2.0.sql
+++ b/src/timestamp9--1.1.0--1.2.0.sql
@@ -1,0 +1,6 @@
+DROP OPERATOR CLASS hash_timestamp9_ops USING hash;
+
+CREATE OPERATOR CLASS hash_timestamp9_ops
+DEFAULT FOR TYPE timestamp9 USING hash FAMILY integer_ops AS
+	OPERATOR 1 =,
+	FUNCTION 1 hash_timestamp9(timestamp9);

--- a/src/timestamp9.sql
+++ b/src/timestamp9.sql
@@ -172,7 +172,7 @@ CREATE OR REPLACE FUNCTION hash_timestamp9(timestamp9) RETURNS integer AS
 LANGUAGE internal IMMUTABLE STRICT PARALLEL SAFE LEAKPROOF;
 
 CREATE OPERATOR CLASS hash_timestamp9_ops
-FOR TYPE timestamp9 USING hash FAMILY integer_ops AS
+DEFAULT FOR TYPE timestamp9 USING hash FAMILY integer_ops AS
 	OPERATOR 1 =,
 	FUNCTION 1 hash_timestamp9(timestamp9);
 

--- a/tests/expected/basics.out
+++ b/tests/expected/basics.out
@@ -215,3 +215,6 @@ select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 microseco
  2019-09-19 23:00:00.123454789 +0200
 (1 row)
 
+CREATE TABLE tbl(ts timestamp9);
+CREATE INDEX ON tbl USING hash (ts);
+CREATE TABLE tbl1(ts timestamp9) PARTITION BY HASH (ts);

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -53,7 +53,8 @@ cd ${EXE_DIR}/sql
 
 # create database and install timestamp9
 ${PSQL} $@ -U $TEST_ROLE_SUPERUSER -d postgres -v ECHO=none -c "CREATE DATABASE \"${TEST_DBNAME}\";"
-${PSQL} $@ -U $TEST_ROLE_SUPERUSER -d ${TEST_DBNAME} -v ECHO=none -c "SET client_min_messages=error; CREATE EXTENSION timestamp9;"
+${PSQL} $@ -U $TEST_ROLE_SUPERUSER -d ${TEST_DBNAME} -v ECHO=none -c "SET client_min_messages=error; CREATE EXTENSION timestamp9; \
+    GRANT CREATE ON SCHEMA public TO PUBLIC;"
 
 export TEST_DBNAME
 

--- a/tests/sql/basics.sql
+++ b/tests/sql/basics.sql
@@ -58,3 +58,8 @@ select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 milliseco
 
 select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 + interval '1 microsecond';
 select '2019-09-19 23:00:00.123456789 +0200'::timestamp9 - interval '2 microseconds';
+
+CREATE TABLE tbl(ts timestamp9);
+CREATE INDEX ON tbl USING hash (ts);
+
+CREATE TABLE tbl1(ts timestamp9) PARTITION BY HASH (ts);

--- a/tests/test-defs.cmake
+++ b/tests/test-defs.cmake
@@ -18,7 +18,7 @@ set(ISOLATION_TEST_SCHEDULE ${CMAKE_CURRENT_BINARY_DIR}/isolation_test_schedule)
 
 set(PG_REGRESS_OPTS_BASE
   --host=${TEST_PGHOST}
-  --load-language=plpgsql
+  --load-extension=plpgsql
   --dlpath=${PROJECT_BINARY_DIR}/src)
 
 set(PG_REGRESS_OPTS_EXTRA


### PR DESCRIPTION
```
postgres=# create table tbl(ts timestamp9);
CREATE TABLE
postgres=# create index on tbl using hash (ts);
ERROR:  data type timestamp9 has no default operator class for access method "hash"
HINT:  You must specify an operator class for the index or define a default operator class for the data type.

postgres=# CREATE TABLE tbl1(ts timestamp9) PARTITION BY HASH (ts);
ERROR:  data type timestamp9 has no default operator class for access method "hash"
HINT:  You must specify a hash operator class or define a default hash operator class for the data type.
```

The DEFAULT option is needed when creating a hash index. This also solves the problem when timestamp9 is used as the partition key.

The hash operator class is resolved in this function in PG.
https://github.com/postgres/postgres/blob/ff9618e82a466fc9c635f9f087776e57b21e4f14/src/backend/commands/indexcmds.c#L2148