### PR TITLE
Allow parsing nanosecond precision timestamps w/o timezone.

### DIFF
--- a/src/timestamp9.c
+++ b/src/timestamp9.c
@@ -224,7 +224,7 @@ timestamp9_in(PG_FUNCTION_ARGS)
 		int num_read;
 		time_t tt;
 
-		num_read = sscanf(str, "%d-%d-%d %d:%d:%d.%lld %s", &tm_.tm_year, &tm_.tm_mon, &tm_.tm_mday, &tm_.tm_hour, &tm_.tm_min, &tm_.tm_sec, &ns, gmt_offset_str);
+		num_read = sscanf(str, "%d-%d-%d %d:%d:%d.%lld %254s", &tm_.tm_year, &tm_.tm_mon, &tm_.tm_mday, &tm_.tm_hour, &tm_.tm_min, &tm_.tm_sec, &ns, gmt_offset_str);
 		if ((num_read == 7 || num_read == 8) && fractional_valid)
 		{
 			int gmt_offset_str_len = strlen(gmt_offset_str);

--- a/tests/expected/basics.out
+++ b/tests/expected/basics.out
@@ -74,12 +74,25 @@ select '2019-09-19 08:30:05.123456789'::timestamp9;
  2019-09-19 08:30:05.123456789 +0100
 (1 row)
 
+-- Test that we can use various timezones.
+select '2019-09-19 08:30:05.123456789 Europe/London'::timestamp9;
+             timestamp9              
+-------------------------------------
+ 2019-09-19 08:30:05.123456789 +0100
+(1 row)
+
+select '2019-09-19 08:30:05.123456789 utc-2'::timestamp9;
+             timestamp9              
+-------------------------------------
+ 2019-09-19 07:30:05.123456789 +0100
+(1 row)
+
 set timezone to 'UTC-2';
 -- Test that we are able to reject bad inputs.
 select '2022-01-25 00:00:00.123456789 +'::timestamp9;
-ERROR:  invalid input format for timestamp9: could not parse gmt offset, required format y-m-d h:m:s.ns [+tz] "2022-01-25 00:00:00.123456789 +" at character 8
+ERROR:  invalid input syntax for type numeric timezone: "+" at character 8
 select '2022-01-25 00:00:00.123456789 abcd'::timestamp9;
-ERROR:  invalid input format for timestamp9: could not parse gmt offset, required format y-m-d h:m:s.ns [+tz] "2022-01-25 00:00:00.123456789 abcd" at character 8
+ERROR:  time zone "abcd" not recognized at character 8
 -- Test that we are able to compare timestamp9 values.
 select '2019-09-19'::timestamp9 < '2019-09-20'::timestamp9, greatest('2020-06-06'::timestamp9, '2019-01-01'::timestamp9);
  ?column? |              greatest               

--- a/tests/expected/basics.out
+++ b/tests/expected/basics.out
@@ -68,6 +68,12 @@ select '2019-09-19 08:30:05'::timestamp9;
  2019-09-19 08:30:05.000000000 +0100
 (1 row)
 
+select '2019-09-19 08:30:05.123456789'::timestamp9;
+             timestamp9              
+-------------------------------------
+ 2019-09-19 08:30:05.123456789 +0100
+(1 row)
+
 set timezone to 'UTC-2';
 -- Test that we are able to compare timestamp9 values.
 select '2019-09-19'::timestamp9 < '2019-09-20'::timestamp9, greatest('2020-06-06'::timestamp9, '2019-01-01'::timestamp9);

--- a/tests/expected/basics.out
+++ b/tests/expected/basics.out
@@ -75,6 +75,11 @@ select '2019-09-19 08:30:05.123456789'::timestamp9;
 (1 row)
 
 set timezone to 'UTC-2';
+-- Test that we are able to reject bad inputs.
+select '2022-01-25 00:00:00.123456789 +'::timestamp9;
+ERROR:  invalid input format for timestamp9: could not parse gmt offset, required format y-m-d h:m:s.ns [+tz] "2022-01-25 00:00:00.123456789 +" at character 8
+select '2022-01-25 00:00:00.123456789 abcd'::timestamp9;
+ERROR:  invalid input format for timestamp9: could not parse gmt offset, required format y-m-d h:m:s.ns [+tz] "2022-01-25 00:00:00.123456789 abcd" at character 8
 -- Test that we are able to compare timestamp9 values.
 select '2019-09-19'::timestamp9 < '2019-09-20'::timestamp9, greatest('2020-06-06'::timestamp9, '2019-01-01'::timestamp9);
  ?column? |              greatest               

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -61,7 +61,7 @@ export TEST_DBNAME
 # we strip out any output between <exclude_from_test></exclude_from_test>
 # and the part about memory usage in EXPLAIN ANALYZE output of Sort nodes
 ${PSQL} -U ${TEST_PGUSER} \
-     -v ON_ERROR_STOP=1 \
+     -v ON_ERROR_STOP=0 \
      -v VERBOSITY=terse \
      -v ECHO=all \
      -v DISABLE_OPTIMIZATIONS=off \

--- a/tests/runner_shared.sh
+++ b/tests/runner_shared.sh
@@ -42,7 +42,7 @@ cd ${EXE_DIR}/sql
 # we strip out any output between <exclude_from_test></exclude_from_test>
 # and the part about memory usage in EXPLAIN ANALYZE output of Sort nodes
 ${PSQL} -U ${TEST_PGUSER} \
-     -v ON_ERROR_STOP=1 \
+     -v ON_ERROR_STOP=0 \
      -v VERBOSITY=terse \
      -v ECHO=all \
      -v TEST_BASE_NAME=${TEST_BASE_NAME} \

--- a/tests/sql/basics.sql
+++ b/tests/sql/basics.sql
@@ -22,6 +22,9 @@ select '2019-09-19 08:30:05 +0100'::timestamp9;
 -- of the current session by default.
 select '2019-09-19 08:30:05'::timestamp9;
 select '2019-09-19 08:30:05.123456789'::timestamp9;
+-- Test that we can use various timezones.
+select '2019-09-19 08:30:05.123456789 Europe/London'::timestamp9;
+select '2019-09-19 08:30:05.123456789 utc-2'::timestamp9;
 set timezone to 'UTC-2';
 
 -- Test that we are able to reject bad inputs.

--- a/tests/sql/basics.sql
+++ b/tests/sql/basics.sql
@@ -24,6 +24,9 @@ select '2019-09-19 08:30:05'::timestamp9;
 select '2019-09-19 08:30:05.123456789'::timestamp9;
 set timezone to 'UTC-2';
 
+-- Test that we are able to reject bad inputs.
+select '2022-01-25 00:00:00.123456789 +'::timestamp9;
+select '2022-01-25 00:00:00.123456789 abcd'::timestamp9;
 
 -- Test that we are able to compare timestamp9 values.
 select '2019-09-19'::timestamp9 < '2019-09-20'::timestamp9, greatest('2020-06-06'::timestamp9, '2019-01-01'::timestamp9);

--- a/tests/sql/basics.sql
+++ b/tests/sql/basics.sql
@@ -21,6 +21,7 @@ select '2019-09-19 08:30:05 +0100'::timestamp9;
 -- NOTE: If we don't specify the timezone when parsing the time, it follows the timezone
 -- of the current session by default.
 select '2019-09-19 08:30:05'::timestamp9;
+select '2019-09-19 08:30:05.123456789'::timestamp9;
 set timezone to 'UTC-2';
 
 


### PR DESCRIPTION
This patch teaches timestamp9 to accept nanosecond precision timestamps w/o timezone information.

e.g.,

```
select '2019-09-19 08:30:05.123456789'::timestamp9;
             timestamp9              
-------------------------------------
 2019-09-19 08:30:05.123456789 +0100
(1 row)

```

Try to address Floris' comments in #9.