### PR TITLE
Fix round off error when cast timestamp9 to timestamptz/timestamp.

### DIFF
--- a/tests/expected/basics.out
+++ b/tests/expected/basics.out
@@ -14,6 +14,43 @@ select 9223372036854775807::timestamp9;
  2262-04-12 01:47:16.854775807 +0200
 (1 row)
 
+-- Test that we are able to convert various date/timestamp types to timestamp9 type.
+select '2023-01-01 00:00:00.123456789'::date::timestamp9;
+             timestamp9              
+-------------------------------------
+ 2023-01-01 00:00:00.000000000 +0200
+(1 row)
+
+select '2023-01-01 00:00:00.123456789'::timestamp::timestamp9;
+             timestamp9              
+-------------------------------------
+ 2023-01-01 00:00:00.123457000 +0200
+(1 row)
+
+select '2023-01-01 00:00:00.123456789'::timestamptz::timestamp9;
+             timestamp9              
+-------------------------------------
+ 2023-01-01 00:00:00.123457000 +0200
+(1 row)
+
+select '2023-01-01 00:00:00.123456789'::timestamp9::date;
+    date    
+------------
+ 01-01-2023
+(1 row)
+
+select '2023-01-01 00:00:00.123456789'::timestamp9::timestamp;
+            timestamp            
+---------------------------------
+ Sun Jan 01 00:00:00.123457 2023
+(1 row)
+
+select '2023-01-01 00:00:00.123456789'::timestamp9::timestamptz;
+             timestamptz             
+-------------------------------------
+ Sun Jan 01 00:00:00.123457 2023 UTC
+(1 row)
+
 -- Test that we are able to convert various formats of timestamps to timestamp9 type.
 select '2019-09-19 08:30:05.123456789 +0200'::timestamp9;
              timestamp9              

--- a/tests/sql/basics.sql
+++ b/tests/sql/basics.sql
@@ -6,6 +6,15 @@ set timezone to 'UTC-2';
 select 0::bigint::timestamp9;
 select 9223372036854775807::timestamp9;
 
+-- Test that we are able to convert various date/timestamp types to timestamp9 type.
+select '2023-01-01 00:00:00.123456789'::date::timestamp9;
+select '2023-01-01 00:00:00.123456789'::timestamp::timestamp9;
+select '2023-01-01 00:00:00.123456789'::timestamptz::timestamp9;
+
+select '2023-01-01 00:00:00.123456789'::timestamp9::date;
+select '2023-01-01 00:00:00.123456789'::timestamp9::timestamp;
+select '2023-01-01 00:00:00.123456789'::timestamp9::timestamptz;
+
 -- Test that we are able to convert various formats of timestamps to timestamp9 type.
 select '2019-09-19 08:30:05.123456789 +0200'::timestamp9;
 select '2019-09-19 08:30:05.123456789-0200'::timestamp9;


### PR DESCRIPTION
When cast the following timestamp9 value to timestamptz/timestamp, the result is not accurate.

```
select '2022-01-01 00:00:00.123456789'::timestamp9::timestamp;
            timestamp
---------------------------------
 Sun Jan 01 00:00:00.123456 2023
(1 row)
```

We shouldn't ignore the fractional parts when doing the division.